### PR TITLE
feat: Make URL shortener service return error and add logging to HTTP

### DIFF
--- a/pkg/domain/url/url_test.go
+++ b/pkg/domain/url/url_test.go
@@ -22,41 +22,47 @@ var _ = Describe("URL shortener", func() {
 	Context("when providing a long URL", func() {
 		It("generates a hash", func() {
 			aLongURL := "https://google.com"
-			shortURL := shortener.HashFromURL(aLongURL)
+			shortURL, err := shortener.HashFromURL(aLongURL)
 
+			Expect(err).To(Succeed())
 			Expect(shortURL.Hash).To(HaveLen(8))
 		})
 
 		It("contains the real value from the original URL", func() {
 			aLongURL := "https://google.com"
-			shortURL := shortener.HashFromURL(aLongURL)
+			shortURL, err := shortener.HashFromURL(aLongURL)
 
+			Expect(err).To(Succeed())
 			Expect(shortURL.LongURL).To(Equal(aLongURL))
 		})
 
 		Context("and the provided URL is not HTTP", func() {
 			It("validates that the provided URL is not valid", func() {
 				aLongURL := "ftp://google.com"
-				shortURL := shortener.HashFromURL(aLongURL)
+				shortURL, err := shortener.HashFromURL(aLongURL)
 
+				Expect(err).To(MatchError(url.ErrInvalidLongURLSpecified))
 				Expect(shortURL).To(BeNil())
 			})
 		})
 
 		Context("when providing different long URLs", func() {
 			It("generates different short URL hashes", func() {
-				shortGoogleURL := shortener.HashFromURL("https://google.com")
-				shortFacebookURL := shortener.HashFromURL("https://facebook.com")
+				shortGoogleURL, err := shortener.HashFromURL("https://google.com")
+				Expect(err).To(Succeed())
+
+				shortFacebookURL, err := shortener.HashFromURL("https://facebook.com")
+				Expect(err).To(Succeed())
 
 				Expect(shortGoogleURL.Hash).ToNot(Equal(shortFacebookURL.Hash))
 			})
 		})
 
 		It("stores the short URL in a repository", func() {
-			shortURL := shortener.HashFromURL("https://unizar.es")
+			shortURL, err := shortener.HashFromURL("https://unizar.es")
+			Expect(err).To(Succeed())
 
 			expectedURLInRepo, err := repository.FindByHash(shortURL.Hash)
-
 			Expect(err).To(Succeed())
 			Expect(expectedURLInRepo.Hash).To(Equal(shortURL.Hash))
 		})

--- a/pkg/infrastructure/database/postgres/postgres.go
+++ b/pkg/infrastructure/database/postgres/postgres.go
@@ -26,18 +26,20 @@ type DB struct {
 }
 
 var (
-	errDuplicateConstraintViolation = "23505"
+	errDuplicateConstraintViolation pq.ErrorCode = "23505"
 )
 
 func (d *DB) Save(url *url.ShortURL) error {
 	shortURL := model.ShortURLFromDomain(url)
 	_, err := d.engine.Insert(&shortURL)
 
-	var pqError pq.Error
-	if errors.Is(err, &pqError) {
-		if pqError.Code == pq.ErrorCode(errDuplicateConstraintViolation) {
+	var pqError *pq.Error
+	if errors.As(err, &pqError) {
+		if pqError.Code == errDuplicateConstraintViolation {
 			return nil
 		}
+	}
+	if err != nil {
 		return fmt.Errorf("unable to save short URL: %w", err)
 	}
 	return nil


### PR DESCRIPTION
Makes the URL shortener service return an error indicating that there was some problem processing the requests.
Also, adds logging to the HTTP application layer that gives some insights that something has gone wrong when it happens.