### PR TITLE
feat: Force valid as true in loadbalancing for demo purposes

### DIFF
--- a/pkg/application/http/handlers_test.go
+++ b/pkg/application/http/handlers_test.go
@@ -93,8 +93,8 @@ var _ = Describe("Application / HTTP", func() {
 			loadBalancedURL, err := loadBalancerURLsRepository.FindLoadBalancedURLByHash("5XEOqhb0")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(loadBalancedURL.LongURLs).To(ConsistOf(
-				url.OriginalURL{URL: "https://google.es"},
-				url.OriginalURL{URL: "https://youtube.com"},
+				url.OriginalURL{URL: "https://google.es", IsValid: true},
+				url.OriginalURL{URL: "https://youtube.com", IsValid: true},
 			))
 		})
 

--- a/pkg/domain/url/load_balancer.go
+++ b/pkg/domain/url/load_balancer.go
@@ -54,7 +54,7 @@ func originalURLsFromRaw(urls []string) []OriginalURL {
 	for _, aURL := range urls {
 		originalURLs = append(originalURLs, OriginalURL{
 			URL:     aURL,
-			IsValid: false,
+			IsValid: true,
 		})
 	}
 	return originalURLs

--- a/pkg/domain/url/load_balancer_test.go
+++ b/pkg/domain/url/load_balancer_test.go
@@ -28,15 +28,15 @@ var _ = Describe("Domain / URL / Load Balancing", func() {
 			Expect(loadBalancedURLs).To(Equal(&url.LoadBalancedURL{
 				Hash: "P3Z83Gpy",
 				LongURLs: []url.OriginalURL{
-					{URL: "aURL", IsValid: false},
-					{URL: "anotherURL", IsValid: false},
+					{URL: "aURL", IsValid: true},
+					{URL: "anotherURL", IsValid: true},
 				},
 			}))
 			Expect(multipleShortURLsRepository.urls).To(ContainElement(Equal(&url.LoadBalancedURL{
 				Hash: "P3Z83Gpy",
 				LongURLs: []url.OriginalURL{
-					{URL: "aURL", IsValid: false},
-					{URL: "anotherURL", IsValid: false},
+					{URL: "aURL", IsValid: true},
+					{URL: "anotherURL", IsValid: true},
 				},
 			})))
 		})


### PR DESCRIPTION
Forces the validation of load-balanced URLs as true, before async validation is implemented, for demo purposes.